### PR TITLE
Fix upload widget accept parameter usage

### DIFF
--- a/frontend/config_page.py
+++ b/frontend/config_page.py
@@ -32,7 +32,14 @@ def config_page():
 
     with ui.row():
         ui.label("Upload PO File")
-        ui.upload(on_upload=handle_po_upload, multiple=False, auto_upload=True, accept=".xlsx")
+        # allow only a single Excel file to be uploaded
+        ui.upload(
+            on_upload=handle_po_upload,
+            multiple=False,
+            auto_upload=True,
+            file_filter="*.xlsx",
+            max_files=1,
+        )
 
     def save_configuration() -> None:
         config["newitems_file"] = new_items_select.value

--- a/frontend/upload_page.py
+++ b/frontend/upload_page.py
@@ -12,4 +12,11 @@ def upload_page() -> None:
             shutil.copyfileobj(e.content, f)
         ui.notify(f"File {e.name} uploaded successfully!")
 
-    ui.upload(on_upload=handle_upload, multiple=False, auto_upload=True, accept=".xlsx")
+    # single Excel file upload widget
+    ui.upload(
+        on_upload=handle_upload,
+        multiple=False,
+        auto_upload=True,
+        file_filter="*.xlsx",
+        max_files=1,
+    )


### PR DESCRIPTION
## Summary
- remove deprecated `accept` argument on NiceGUI upload widgets
- use `file_filter` and `max_files` to only allow one `.xlsx` file

## Testing
- `python -m py_compile frontend/config_page.py frontend/upload_page.py app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'nicegui')*

------
https://chatgpt.com/codex/tasks/task_b_688525e857f4832d951d3c7e7428e8c6