### PR TITLE
Remove unused configure_matching module

### DIFF
--- a/frontend/configure_matching.py
+++ b/frontend/configure_matching.py
@@ -1,9 +1,0 @@
-# frontend/configure_matching.py
-"""Page to configure matching settings."""
-
-from . import config_page
-
-
-def configure_matching_page():
-    """Display the configuration options for matching."""
-    config_page.config_page()


### PR DESCRIPTION
## Summary
- delete unused `configure_matching.py`

## Testing
- `find . -name '*.py' | xargs python -m py_compile`
- `python -m py_compile app.py`
- *(failed: `pip install -r requirements.txt` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_688526275f28832d9cdf79da1e4fb30b